### PR TITLE
Adding logging to patch match setup operations

### DIFF
--- a/patchmatch/patch_match.py
+++ b/patchmatch/patch_match.py
@@ -114,31 +114,31 @@ def download_url_to_file(url, dst, hash_prefix=None, progress=True):
 import json
 import platform
 
-# Get release information from github
-release_response = urlopen(release_url)
-release_json = json.loads(release_response.read())
-
-# Filter to assets for platform
-platform_slug = f'{platform.system().lower()}_{platform.machine().lower()}'
-platform_assets = list(filter(lambda a: platform_slug in a['name'], release_json['assets']))
-if 'windows' in platform_slug:
-    platform_assets.extend(filter(lambda a: a['name'] == 'opencv_world460.dll', release_json['assets']))
-
-# Get assets
-pypatchmatch_lib = None
-for asset in platform_assets:
-    lib_name = asset['name']
-    lib_url = asset['browser_download_url']
-
-    if not os.path.exists(osp.join(osp.dirname(__file__), lib_name)):
-        logger.info(f'Downloading patchmatch libraries from github release {lib_url}')
-        download_url_to_file(url=lib_url, dst=osp.join(osp.dirname(__file__), lib_name))
-
-    # Store patchmatch library name
-    if lib_name.startswith('libpatchmatch_'):
-        pypatchmatch_lib = lib_name
-
 try:
+    # Get release information from github
+    release_response = urlopen(release_url)
+    release_json = json.loads(release_response.read())
+
+    # Filter to assets for platform
+    platform_slug = f'{platform.system().lower()}_{platform.machine().lower()}'
+    platform_assets = list(filter(lambda a: platform_slug in a['name'], release_json['assets']))
+    if 'windows' in platform_slug:
+        platform_assets.extend(filter(lambda a: a['name'] == 'opencv_world460.dll', release_json['assets']))
+
+    # Get assets
+    pypatchmatch_lib = None
+    for asset in platform_assets:
+        lib_name = asset['name']
+        lib_url = asset['browser_download_url']
+
+        if not os.path.exists(osp.join(osp.dirname(__file__), lib_name)):
+            logger.info(f'Downloading patchmatch libraries from github release {lib_url}')
+            download_url_to_file(url=lib_url, dst=osp.join(osp.dirname(__file__), lib_name))
+
+        # Store patchmatch library name
+        if lib_name.startswith('libpatchmatch_'):
+            pypatchmatch_lib = lib_name
+
     # Compile if we didn't find a platform-compatible version (and it's not compiled already)
     if pypatchmatch_lib is None:
         pypatchmatch_lib = 'libpatchmatch.so'

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ requirements = [
 setup(
     name='pypatchmatch',
     packages=['patchmatch'],
-    version='0.1.3',
+    version='0.1.4',
     url='https://github.com/invoke-ai/PyPatchMatch',
     python_requires='>=3.9',
     install_requires=requirements,


### PR DESCRIPTION
Adds logging to setup operations.

Logging for `make` can be enabled with `export INVOKEAI_DEBUG_PATCHMATCH=True`.