### PR TITLE
add opencv4

### DIFF
--- a/patchmatch/Makefile
+++ b/patchmatch/Makefile
@@ -16,8 +16,10 @@ CXXFLAGS = -std=c++14
 CXXFLAGS += -Ofast -ffast-math -w
 # CXXFLAGS += -g
 CXXFLAGS += $(shell pkg-config --cflags opencv) -fPIC
+CXXFLAGS += $(shell pkg-config --cflags opencv4) -fPIC
 CXXFLAGS += $(INCLUDE_DIR)
-LDFLAGS = $(shell pkg-config --cflags --libs opencv) -shared -fPIC
+LDFLAGS += $(shell pkg-config --cflags --libs opencv) -shared -fPIC
+LDFLAGS += $(shell pkg-config --cflags --libs opencv4) -shared -fPIC
 
 
 CXXSOURCES = $(shell find $(SRC_DIR)/ -name "*.cpp")

--- a/patchmatch/patch_match.py
+++ b/patchmatch/patch_match.py
@@ -26,7 +26,7 @@ repo = 'https://api.github.com/repos/invoke-ai/PyPatchMatch/'
 release_id = 'tags/0.1.1'
 release_url = f'{repo}releases/{release_id}'
 
-install_help_location = 'https://github.com/invoke-ai/InvokeAI/blob/main/docs/installation/INSTALL_PATCHMATCH.md'
+install_help_location = 'https://invoke-ai.github.io/InvokeAI/installation/060_INSTALL_PATCHMATCH/'
 
 # Create the logger
 logger = logging.getLogger(__name__)
@@ -153,7 +153,7 @@ try:
             if os.environ.get('INVOKEAI_DEBUG_PATCHMATCH'):
                 make_stdout = None
                 make_stderr = None
-            
+
             logger.info('Compiling and loading c extensions from "{}".'.format(osp.realpath(osp.dirname(__file__))))
             # subprocess.check_call(['./travis.sh'], cwd=osp.dirname(__file__))
             # TODO: pipe output to logger instead of just swallowing it

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,8 @@ with open("README.md", "r", encoding="utf-8") as readme_file:
 
 requirements = [
     "numpy",
-    "pillow"
+    "pillow",
+    "tqdm"
 ]
 
 setup(


### PR DESCRIPTION
This way there is no need to create a symlink from `opencv4.pc` to `opencv.pc`

Works on
- MacOS when OpenCV is installed via brew, macports or if compiled from [current sources](https://github.com/opencv/opencv)
- [Debian based Distros](https://invoke-ai.github.io/InvokeAI/installation/060_INSTALL_PATCHMATCH/#debian-based-distros)
- [Arch Based Distros](https://invoke-ai.github.io/InvokeAI/installation/060_INSTALL_PATCHMATCH/#arch-based-distros)

